### PR TITLE
Fix tests for GHC 9.x

### DIFF
--- a/test/Data/Diverse/ManySpec.hs
+++ b/test/Data/Diverse/ManySpec.hs
@@ -305,7 +305,7 @@ spec = do
 
         it "with duplicate fields has setter for unique fields 'amend''" $ do
             let x = (5 :: Int) ./ False ./ 'X' ./ Just 'O' ./ (6 :: Int) ./ Just 'A' ./ nil
-            amend' @ '[Bool, Char] x (True ./ 'B' ./ nil) `shouldBe`
+            amend' @'[Bool, Char] x (True ./ 'B' ./ nil) `shouldBe`
                 (5 :: Int) ./ True ./ 'B' ./ Just 'O' ./ (6 :: Int) ./ Just 'A' ./ nil
 
         it "can be folded with 'Many' handlers using 'forMany' or 'collect'" $ do


### PR DESCRIPTION
Putting spaces after `@` (`TypeApplication`) is no longer valid since GHC 9.x

```
[1 of 4] Compiling Data.Diverse.ManySpec ( test/Data/Diverse/ManySpec.hs, dist/build/data-diverse-test/data-diverse-test-tmp/Data/Diverse/ManySpec.o )

test/Data/Diverse/ManySpec.hs:308:24: error:
    parse error on input ‘Bool’
    |
308 |             amend' @ '[Bool, Char] x (True ./ 'B' ./ nil) `shouldBe`
    |                        ^^^^
```